### PR TITLE
Bump version to v0.202.0-rc1

### DIFF
--- a/.github/workflows/ckb-mock-tx-types.yml
+++ b/.github/workflows/ckb-mock-tx-types.yml
@@ -3,16 +3,20 @@ name: ckb-mock-tx-types
 on:
   pull_request:
     branches: [ main ]
-    paths: "ckb-mock-tx-types/**"
+    paths: ["ckb-mock-tx-types/**", "Cargo.toml"]
   push:
     branches: [ main ]
-    paths: "ckb-mock-tx-types/**"
+    paths: ["ckb-mock-tx-types/**", "Cargo.toml"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Setup CKB VM
+      run: |
+        cd ckb-vm-test-suite
+        make ckb-vm
     - name: Build
       run: |
         cd ckb-mock-tx-types

--- a/.github/workflows/ckb-mock-tx-types.yml
+++ b/.github/workflows/ckb-mock-tx-types.yml
@@ -3,10 +3,10 @@ name: ckb-mock-tx-types
 on:
   pull_request:
     branches: [ main ]
-    paths: ["ckb-mock-tx-types/**", "Cargo.toml"]
+    paths: ["ckb-mock-tx-types/**", "Cargo.toml", "Cargo.lock"]
   push:
     branches: [ main ]
-    paths: ["ckb-mock-tx-types/**", "Cargo.toml"]
+    paths: ["ckb-mock-tx-types/**", "Cargo.toml", "Cargo.lock"]
 
 jobs:
   build:

--- a/.github/workflows/ckb-vm-test-suite.yml
+++ b/.github/workflows/ckb-vm-test-suite.yml
@@ -3,10 +3,10 @@ name: ckb-vm-test-suite
 on:
   pull_request:
     branches: [ main ]
-    paths: "ckb-vm-test-suite/**"
+    paths: ["ckb-vm-test-suite/**", "Cargo.toml"]
   push:
     branches: [ main ]
-    paths: "ckb-vm-test-suite/**"
+    paths: ["ckb-vm-test-suite/**", "Cargo.toml"]
 
 jobs:
   build:

--- a/.github/workflows/ckb-vm-test-suite.yml
+++ b/.github/workflows/ckb-vm-test-suite.yml
@@ -3,10 +3,10 @@ name: ckb-vm-test-suite
 on:
   pull_request:
     branches: [ main ]
-    paths: ["ckb-vm-test-suite/**", "Cargo.toml"]
+    paths: ["ckb-vm-test-suite/**", "Cargo.toml", "Cargo.lock"]
   push:
     branches: [ main ]
-    paths: ["ckb-vm-test-suite/**", "Cargo.toml"]
+    paths: ["ckb-vm-test-suite/**", "Cargo.toml", "Cargo.lock"]
 
 jobs:
   build:

--- a/.github/workflows/ckb-x64-simulator.yml
+++ b/.github/workflows/ckb-x64-simulator.yml
@@ -3,10 +3,10 @@ name: ckb-x64-simulator
 on:
   pull_request:
     branches: [ main ]
-    paths: ["ckb-x64-simulator/**", "Cargo.toml"]
+    paths: ["ckb-x64-simulator/**", "Cargo.toml", "Cargo.lock"]
   push:
     branches: [ main ]
-    paths: ["ckb-x64-simulator/**", "Cargo.toml"]
+    paths: ["ckb-x64-simulator/**", "Cargo.toml", "Cargo.lock"]
 
 jobs:
   build:

--- a/.github/workflows/ckb-x64-simulator.yml
+++ b/.github/workflows/ckb-x64-simulator.yml
@@ -3,19 +3,26 @@ name: ckb-x64-simulator
 on:
   pull_request:
     branches: [ main ]
-    paths: "ckb-x64-simulator/**"
+    paths: ["ckb-x64-simulator/**", "Cargo.toml"]
   push:
     branches: [ main ]
-    paths: "ckb-x64-simulator/**"
+    paths: ["ckb-x64-simulator/**", "Cargo.toml"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Setup CKB VM
+      run: |
+        cd ckb-vm-test-suite
+        make ckb-vm
     - name: Setup Clang
       run: |
         clang --version
+    - name: Setup Clippy
+      run: |
+        rustup component add clippy
     - name: Setup Rust Target
       run: |
         rustup target add riscv64imac-unknown-none-elf

--- a/.github/workflows/release-ckb-mock-tx-types.yml
+++ b/.github/workflows/release-ckb-mock-tx-types.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Setup CKB VM
+      run: |
+        cd ckb-vm-test-suite
+        make ckb-vm
     - name: Publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-ckb-x64-simulator.yml
+++ b/.github/workflows/release-ckb-x64-simulator.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Setup CKB VM
+      run: |
+        cd ckb-vm-test-suite
+        make ckb-vm
     - name: Setup Clang
       run: |
         clang --version

--- a/.github/workflows/release-spike-sys.yml
+++ b/.github/workflows/release-spike-sys.yml
@@ -10,7 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Steup
+    - name: Setup CKB VM
+      run: |
+        cd ckb-vm-test-suite
+        make ckb-vm
+    - name: Steup Device Tree Compiler
       run: |
         sudo apt install device-tree-compiler
     - name: Publish

--- a/.github/workflows/spike-sys.yml
+++ b/.github/workflows/spike-sys.yml
@@ -3,10 +3,10 @@ name: spike-sys
 on:
   pull_request:
     branches: [ main ]
-    paths: ["spike-sys/**", "Cargo.toml"]
+    paths: ["spike-sys/**", "Cargo.toml", "Cargo.lock"]
   push:
     branches: [ main ]
-    paths: ["spike-sys/**", "Cargo.toml"]
+    paths: ["spike-sys/**", "Cargo.toml", "Cargo.lock"]
 
 jobs:
   build:

--- a/.github/workflows/spike-sys.yml
+++ b/.github/workflows/spike-sys.yml
@@ -3,17 +3,21 @@ name: spike-sys
 on:
   pull_request:
     branches: [ main ]
-    paths: "spike-sys/**"
+    paths: ["spike-sys/**", "Cargo.toml"]
   push:
     branches: [ main ]
-    paths: "spike-sys/**"
+    paths: ["spike-sys/**", "Cargo.toml"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Steup
+    - name: Setup CKB VM
+      run: |
+        cd ckb-vm-test-suite
+        make ckb-vm
+    - name: Steup Device Tree Compiler
       run: |
         sudo apt install device-tree-compiler
     - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,37 +30,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "argparse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec 0.8.0",
-]
-
-[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -155,36 +134,36 @@ dependencies = [
 
 [[package]]
 name = "ckb-channel"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01c19d4cd17c7dade4e17470bf4c9383ca11f1ea1e17cb65075eb62663b67e3"
+checksum = "2a73f40a15d7a0844a1a0a53651fe5472ff2d123c6fbe80069f27e27ea334f2a"
 dependencies = [
  "crossbeam-channel",
 ]
 
 [[package]]
 name = "ckb-constant"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946c260892eee2bead85705be334f871076f15724cb4f69d0a43701899e45cb8"
+checksum = "fea099b3d8b46c75822c499c449dab12f64e357b89c022886f5de9fb2beedb4c"
 
 [[package]]
 name = "ckb-error"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80333cbe31b5a8c9dbdd381a9baab5903f8f502c379c7208d44a19f429054dc2"
+checksum = "e732fb93451cfd65e4159615a60365eef978252e4a0b61f9f9385f9d2b9c8f5e"
 dependencies = [
  "anyhow",
  "ckb-occupied-capacity",
- "derive_more",
+ "derive_more 1.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6bbcb0643a3e983cdc2a75bd4a84746103a622490c0d08256ab9a97c12d8b27"
+checksum = "1d0df5030c80732a7c1c98bf529bafd05df477838b35a40c3d998a9796f4a0ee"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
@@ -192,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230aba1d073a0cc4ec9b0b74a9f166020ebaad439b5e4dd4518606a20cd94661"
+checksum = "7c555de541473bd73419c94f04d98b93ab3175b364e0211efd922cbcca1fa16b"
 dependencies = [
  "ckb_schemars",
  "faster-hex",
@@ -204,21 +183,21 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-macros"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4f59e054081f9955fb9059736a1e4ff4fc6f1e29ad894a9caaa2c78d5cb574"
+checksum = "fd9d17ab547ba088b31ddfb058975d9c1f3c0d8e8b094dd8d681bffff33c35cf"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "ckb-gen-types"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8b9b56ee90afca6710a512abac5c4d7dba69b39b63ed9c246ec17aee764bf8"
+checksum = "315b8f38f4d08b4de55dfee99a6866930ce76762349cc51d3abd45694950eb41"
 dependencies = [
  "cfg-if",
  "ckb-error",
@@ -231,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-hash"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93571b17af91fc16f03275bd70612e16092ad4d2e89eaed9cdf513cd3f1e20e7"
+checksum = "c497f1a9922934b3d702178d230e07f15e84b06c429f0719e9686d1d36caa20b"
 dependencies = [
  "blake2b-ref",
  "blake2b-rs",
@@ -241,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-jsonrpc-types"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fa22c16f8b2ea5f97a9caade99c0cb21e339d7b0a01f7262682fe434156c8b"
+checksum = "c8199f4b7aa07b7bc31fb27d72ac43a4669a1cf3f0e8c6fd5c168011c88aafbd"
 dependencies = [
  "ckb-types",
  "ckb_schemars",
@@ -263,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-mock-tx-types"
-version = "0.200.1"
+version = "0.202.0-rc1"
 dependencies = [
  "ckb-jsonrpc-types",
  "ckb-traits",
@@ -273,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e8200ffb81ab6296944c408bf26bafa708e50f864138da8ccd888e9988c632"
+checksum = "834a6dd2257b3c6614b0b6e1844322a3a6176e259bf899c6f5bc38dba5f4adfe"
 dependencies = [
  "ckb-occupied-capacity-core",
  "ckb-occupied-capacity-macros",
@@ -283,29 +262,29 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity-core"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b35c451084252f1471acbe06284363fa9bcce1367b4fa31ac18ac0df0ea269f"
+checksum = "6abfb2cafc0cd8c92e98cfc64b6b3c35176d23cf44534f85f19033a7d3798169"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ckb-occupied-capacity-macros"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a08d40765806c534aa4e55dd73b17c6c30edfc86c266e83bd37b7349dd2fbf"
+checksum = "43c1e33024eb0c21c7b7ee2b1360bfb1f7eebb72659b83eb53919946e2917a84"
 dependencies = [
  "ckb-occupied-capacity-core",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "ckb-rational"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4224693f82c2380a319efc4841b29d90726a765b50776ae7fd66a5537d762ab8"
+checksum = "6a3ac25ce804b6cd0919a2ba4a00ae8a92628a1dd2b6d1fb4990e785d2ae1711"
 dependencies = [
  "numext-fixed-uint",
  "serde",
@@ -313,20 +292,20 @@ dependencies = [
 
 [[package]]
 name = "ckb-traits"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1ea54ff280b7167818ed7ec05a1e03d8a27ea086d1057c4a505b6781a958f"
+checksum = "33c5548a6028cdbc027dde81423d4ab72f30d0bb1fd8aeba6fd0bd2a280b87ff"
 dependencies = [
  "ckb-types",
 ]
 
 [[package]]
 name = "ckb-types"
-version = "0.200.0"
+version = "0.202.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d31954ae56109ea088572bad1c194ac0ed709f7fd7fd01dfcf338f864699cad"
+checksum = "868da3f07e37440bfe1ab42fb52dc3d1c69f558dc5ab72627bbfe83807b77c40"
 dependencies = [
- "bit-vec 0.6.3",
+ "bit-vec",
  "bytes",
  "ckb-channel",
  "ckb-constant",
@@ -337,7 +316,7 @@ dependencies = [
  "ckb-merkle-mountain-range",
  "ckb-occupied-capacity",
  "ckb-rational",
- "derive_more",
+ "derive_more 1.0.0",
  "golomb-coded-set",
  "merkle-cbt",
  "molecule",
@@ -347,20 +326,17 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.24.0"
+version = "0.24.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad137e2f1c9a363ce19a883a2113b1dfcc00a936945e34b62e3726c49e7171fb"
 dependencies = [
- "argparse",
  "byteorder",
  "bytes",
  "cc",
  "ckb-vm-definitions",
- "criterion",
- "derive_more",
+ "derive_more 0.99.20",
  "goblin 0.2.3",
  "goblin 0.4.0",
- "jemalloc-ctl",
- "jemallocator",
- "proptest",
  "rand 0.7.3",
  "scroll",
  "serde",
@@ -368,14 +344,16 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.24.0"
+version = "0.24.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b436017fd6676bea413d54e07a5a9cc1d7c4b5c02e4ab07d3527225a5de6677"
 dependencies = [
  "paste",
 ]
 
 [[package]]
 name = "ckb-vm-test-suite"
-version = "0.200.1"
+version = "0.202.0-rc1"
 dependencies = [
  "ckb-vm",
  "criterion",
@@ -384,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-x64-simulator"
-version = "0.200.1"
+version = "0.202.0-rc1"
 dependencies = [
  "cc",
  "ckb-mock-tx-types",
@@ -449,12 +427,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "criterion"
@@ -540,6 +515,19 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -553,7 +541,6 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -573,32 +560,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "errno"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "faster-hex"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
@@ -609,17 +574,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -717,37 +671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jemalloc-ctl"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cffc705424a344c054e135d12ee591402f4539245e8bbd64e6c9eaa9458b63c"
-dependencies = [
- "jemalloc-sys",
- "libc",
- "paste",
-]
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,12 +701,6 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -943,32 +860,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
-dependencies = [
- "bit-set",
- "bit-vec 0.8.0",
- "bitflags",
- "lazy_static",
- "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,17 +889,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
@@ -1025,16 +905,6 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1058,15 +928,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
@@ -1081,15 +942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1142,16 +994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustix"
-version = "1.0.7"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
+ "semver",
 ]
 
 [[package]]
@@ -1159,18 +1007,6 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -1206,6 +1042,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -1264,7 +1106,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "spike-sys"
-version = "0.200.1"
+version = "0.202.0-rc1"
 
 [[package]]
 name = "syn"
@@ -1286,19 +1128,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
-dependencies = [
- "fastrand",
- "getrandom 0.3.3",
- "once_cell",
- "rustix",
- "windows-sys",
 ]
 
 [[package]]
@@ -1332,37 +1161,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"
@@ -1379,12 +1187,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,22 +4,22 @@ members = ["ckb-mock-tx-types", "ckb-vm-test-suite", "ckb-x64-simulator", "spike
 exclude = ["deps/ckb-vm"]
 
 [workspace.package]
-version = "0.200.1"
+version = "0.202.0-rc1"
 license = "MIT"
 edition = "2024"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 
 [workspace.dependencies]
 # CKB dependencies
-ckb-jsonrpc-types = "=0.200.0"
-ckb-traits = "=0.200.0"
-ckb-types = "=0.200.0"
-ckb-vm = "=0.24.13"
+ckb-jsonrpc-types = "=0.202.0-rc1"
+ckb-traits = "=0.202.0-rc1"
+ckb-types = "=0.202.0-rc1"
+ckb-vm = "=0.24.14"
 
 # Crates defined in current workspace
-ckb-mock-tx-types = { path = "ckb-mock-tx-types", version = "0.200.1" }
-ckb-x64-simulator = { path = "ckb-x64-simulator", version = "0.200.1" }
-spike-sys = { path = "spike-sys", version = "0.200.1" }
+ckb-mock-tx-types = { path = "ckb-mock-tx-types", version = "0.202.0-rc1" }
+ckb-x64-simulator = { path = "ckb-x64-simulator", version = "0.202.0-rc1" }
+spike-sys = { path = "spike-sys", version = "0.202.0-rc1" }
 
 # Other common crates
 criterion = "0.5.1"

--- a/ckb-x64-simulator/tests/scripts/find_clang
+++ b/ckb-x64-simulator/tests/scripts/find_clang
@@ -7,23 +7,29 @@ if [[ -n "${CLANG}" ]]; then
   exit 0
 fi
 
-CANDIDATES=("clang" "clang-16" "clang-17" "clang-18")
+# To cope with packaging messes from different distros, we would search
+# for a different binary other than clang, then convert it back to clang
+# at the end.
+SEARCH_TARGET="${SEARCH_TARGET:-llvm-strip}"
+
+CANDIDATES=("${SEARCH_TARGET}" "${SEARCH_TARGET}-19" "${SEARCH_TARGET}-18" "${SEARCH_TARGET}-17" "${SEARCH_TARGET}-16")
 
 BREW_PREFIX=$(brew --prefix 2> /dev/null)
 if [[ -n "${BREW_PREFIX}" ]]; then
   CANDIDATES+=(
-    "${BREW_PREFIX}/opt/llvm/bin/clang"
-    "${BREW_PREFIX}/opt/llvm@16/bin/clang"
-    "${BREW_PREFIX}/opt/llvm@17/bin/clang"
-    "${BREW_PREFIX}/opt/llvm@18/bin/clang"
+    "${BREW_PREFIX}/opt/llvm/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@19/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@18/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@17/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@16/bin/${SEARCH_TARGET}"
   )
 fi
 
 for candidate in ${CANDIDATES[@]}; do
-  OUTPUT=$($candidate -dumpversion 2> /dev/null | cut -d'.' -f 1)
+  OUTPUT=$($candidate --version 2> /dev/null | grep 'version [0-9]' | head -n 1 | cut -d'.' -f 1 | grep -o '[0-9][0-9]*')
 
   if [[ $((OUTPUT)) -ge 16 ]]; then
-    echo "$candidate"
+    echo "${candidate/${SEARCH_TARGET}/clang}"
     exit 0
   fi
 done

--- a/ckb-x64-simulator/tests/scripts/reproducible_build_docker
+++ b/ckb-x64-simulator/tests/scripts/reproducible_build_docker
@@ -7,8 +7,8 @@
 set -ex
 
 DOCKER="${DOCKER:-docker}"
-# docker pull docker.io/cryptape/llvm-n-rust:20240630
-DOCKER_IMAGE="${DOCKER_IMAGE:-docker.io/cryptape/llvm-n-rust@sha256:bafaf76d4f342a69b8691c08e77a330b7740631f3d1d9c9bee4ead521b29ee55}"
+# docker pull docker.io/cryptape/llvm-n-rust:20250117
+DOCKER_IMAGE="${DOCKER_IMAGE:-docker.io/cryptape/llvm-n-rust@sha256:12e7821cb9c7cbc8988d5b1d60bcc87da4cedcf3eea32df1d8833328c5a69f88}"
 CHECKSUM_FILE_PATH="${CHECKSUM_FILE_PATH:-checksums.txt}"
 
 # We are parsing command line arguments based on tips from:


### PR DESCRIPTION
- Update ckb to v0.202.0-rc1
- ckb-x64-simulator/tests/scripts/find_clang is an old version, it can only find clang but not clang-18, update it.
- https://github.com/nervosnetwork/ckb-vm-contrib/blob/main/ckb-vm-test-suite/Cargo.toml#L13 In this way, if ckb-vm is not found in the relevant path, the entire workspace manifest parsing will fail. Update all CIs and manually pull ckb-vm.