### PR TITLE
chore: add deps-clean target to Makefiles for secp256k1 and sphincsplus

### DIFF
--- a/ckb-vm-test-suite/programs/Makefile
+++ b/ckb-vm-test-suite/programs/Makefile
@@ -106,6 +106,12 @@ clean:
 	cargo clean
 	$(foreach dir, $(wildcard contracts/*), $(MAKE) -e -C $(dir) clean;)
 
+deps-clean:
+	make -C contracts/secp256k1_ecdsa deps-clean
+	make -C contracts/secp256k1_schnorr deps-clean
+	make -C contracts/sphincsplus_ref deps-clean
+
+
 TEMPLATE_TYPE := --git
 TEMPLATE_REPO := https://github.com/cryptape/ckb-script-templates
 CRATE :=

--- a/ckb-vm-test-suite/programs/contracts/secp256k1_ecdsa/Makefile
+++ b/ckb-vm-test-suite/programs/contracts/secp256k1_ecdsa/Makefile
@@ -118,6 +118,12 @@ cargo:
 clean:
 	rm -f $(BINARIES)
 
+deps-clean:
+	cd compiler-rt-builtins-riscv && make clean || true
+	cd musl && make clean || true
+	rm -rf secp256k1/build || true
+	rm -rf compiler-rt-builtins-riscv musl secp256k1 || true
+
 prepare:
 	rustup target add riscv64imac-unknown-none-elf
 

--- a/ckb-vm-test-suite/programs/contracts/secp256k1_schnorr/Makefile
+++ b/ckb-vm-test-suite/programs/contracts/secp256k1_schnorr/Makefile
@@ -118,6 +118,12 @@ cargo:
 clean:
 	rm -f $(BINARIES)
 
+deps-clean:
+	cd compiler-rt-builtins-riscv && make clean || true
+	cd musl && make clean || true
+	rm -rf secp256k1/build || true
+	rm -rf compiler-rt-builtins-riscv musl secp256k1 || true
+
 prepare:
 	rustup target add riscv64imac-unknown-none-elf
 

--- a/ckb-vm-test-suite/programs/contracts/sphincsplus_ref/Makefile
+++ b/ckb-vm-test-suite/programs/contracts/sphincsplus_ref/Makefile
@@ -143,6 +143,12 @@ cargo:
 clean:
 	cargo clean
 
+deps-clean:
+	cd compiler-rt-builtins-riscv && make clean || true
+	cd musl && make clean || true
+	rm -rf compiler-rt-builtins-riscv musl sphincsplus || true
+
+
 prepare:
 	rustup target add riscv64imac-unknown-none-elf
 


### PR DESCRIPTION
When we switch toolchain version, Need to to clean dependencies also.
