### PR TITLE
feat: use lld linker for test contracts

### DIFF
--- a/ckb-vm-test-suite/programs/contracts/secp256k1_ecdsa/Makefile
+++ b/ckb-vm-test-suite/programs/contracts/secp256k1_ecdsa/Makefile
@@ -45,6 +45,7 @@ CFLAGS_CKBVM_SECP256K1 = $(CFLAGS_CKBVM_BASE) \
 	-isystem musl/release/include \
 	-DECMULT_WINDOW_SIZE=6 -DENABLE_MODULE_RECOVERY
 CFLAGS_CKBVM_SECP256K1_ECDSA = $(CFLAGS_CKBVM_BASE) \
+	-fuse-ld=lld \
 	-isystem musl/release/include \
 	-Isecp256k1/include -Isecp256k1/src \
 	-Lmusl/release/lib -Lcompiler-rt-builtins-riscv/build \

--- a/ckb-vm-test-suite/programs/contracts/secp256k1_schnorr/Makefile
+++ b/ckb-vm-test-suite/programs/contracts/secp256k1_schnorr/Makefile
@@ -45,6 +45,7 @@ CFLAGS_CKBVM_SECP256K1 = $(CFLAGS_CKBVM_BASE) \
 	-isystem musl/release/include \
 	-DECMULT_WINDOW_SIZE=6 -DENABLE_MODULE_RECOVERY -DENABLE_MODULE_SCHNORRSIG -DENABLE_MODULE_EXTRAKEYS
 CFLAGS_CKBVM_SECP256K1_SCHNORR = $(CFLAGS_CKBVM_BASE) \
+	-fuse-ld=lld \
 	-isystem musl/release/include \
 	-Isecp256k1/include -Isecp256k1/src \
 	-Lmusl/release/lib -Lcompiler-rt-builtins-riscv/build \

--- a/ckb-vm-test-suite/programs/contracts/sphincsplus_ref/Makefile
+++ b/ckb-vm-test-suite/programs/contracts/sphincsplus_ref/Makefile
@@ -73,6 +73,7 @@ CFLAGS_CKBVM_BASE = --target=riscv64-unknown-elf -march=rv64imc_zba_zbb_zbc_zbs 
 	$(CLANG_OPTIMIZER) \
 	-fdata-sections -ffunction-sections
 CFLAGS_CKBVM_SPHINCSPLUS = $(CFLAGS_CKBVM_BASE) \
+	-fuse-ld=lld \
 	-isystem musl/release/include \
 	-I sphincsplus/ref \
 	-Lmusl/release/lib -Lcompiler-rt-builtins-riscv/build \


### PR DESCRIPTION
When both riscv64-unknown-elf-gcc and clang exist, clang will use the ld linker by default. Adding this parameter forces clang to use lld.