### PR TITLE
ci: restrict benchmark workflow to main repository

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   benchmark:
+    if: github.repository == 'nervosnetwork/ckb-vm-contrib'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Avoid performing performance tests in a forked repository.